### PR TITLE
Fix the use of USB gamepads

### DIFF
--- a/org.bitfighter.Bitfighter.yaml
+++ b/org.bitfighter.Bitfighter.yaml
@@ -1,12 +1,16 @@
 app-id: org.bitfighter.Bitfighter
 runtime: org.freedesktop.Platform
-runtime-version: 22.08
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: bitfighter
 rename-icon: bitfighter
 rename-desktop-file: bitfighter.desktop
 finish-args:
-  - --device=dri
+# We must use `all` to get USB controllers. This is regrettable, since it
+# exposes way more than just controllers. If "just controllers" are added
+# to a future flatpak spec, we will need to include `dri` which was here
+# before we swapped to `all`.
+  - --device=all 
   - --share=network
   - --share=ipc
   - --socket=x11


### PR DESCRIPTION
Regrettably, this does require we pass in all devices to the flatpak environment, but it seems to be pretty standard practice among all games and game tools at the moment.

As a driveby, capture the runtime-version as a string, fixing a warning in the flatpak-builder about certain yaml parsers interpreting it as a number:
```
casey on WATERFALCON in org.bitfighter.Bitfighter on  master 
at 15:18:58 🍀 flatpak-builder --user --install --force-clean build-dir org.bitfighter.Bitfighter.yaml 

(flatpak-builder:2): flatpak-builder-WARNING **: 15:19:17.844: 3:18: '22.08' will be parsed as a number by many YAML parsers
```

## Verification
Before, when running the Flatpak of bitfighter on my desktop:
```
casey on WATERFALCON in org.bitfighter.Bitfighter on  master took 3s 
at 15:19:20 🍀 flatpak run org.bitfighter.Bitfighter 
Copying resources
sh: line 1: xdg-mime: command not found
Welcome to Bitfighter!
Bye!
```
After, with this change, Bitfighter reports finding my USB gamepad!
```
casey on WATERFALCON in org.bitfighter.Bitfighter on  master [!] took 3s 
at 15:23:46 🍀 flatpak run org.bitfighter.Bitfighter
Copying resources
1 joystick(s) detected:
  1. [GameController] "PowerA 1428124-01"
Using controller 0 "PowerA 1428124-01"
sh: line 1: xdg-mime: command not found
Welcome to Bitfighter!
Client connecting to master [bitfighter.org:25955]
Client established connection with Master Server
Bye!
```

Note the error about `xdg-mime` is a bug in Bitfighter's Discord integration and unrelated to this change. We root-caused it for the Snap package over on https://github.com/bitfighter/bitfighter/issues/640, and I think there's no "easy" fix for flatpak.
